### PR TITLE
Prevent Loading Script When Credentials Not Set

### DIFF
--- a/app/views/workarea/storefront/analytics/_google_analytics.html.haml
+++ b/app/views/workarea/storefront/analytics/_google_analytics.html.haml
@@ -1,6 +1,7 @@
-%meta{ property: 'ga-tracking-id', content: Workarea.config.google_analytics_tracking_id }
-:javascript
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+- if Workarea.config.google_analytics_tracking_id.present?
+  %meta{ property: 'ga-tracking-id', content: Workarea.config.google_analytics_tracking_id }
+  :javascript
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');


### PR DESCRIPTION
Only load the `<script>` needed to pull in GA when your tracking ID is
actually set up in configuration.

GOOGLEANALYTICS-2