### PR TITLE
Don't Call Google Analytics Until It's Defined

### DIFF
--- a/app/assets/javascripts/workarea/storefront/google_analytics/modules/adapter.js
+++ b/app/assets/javascripts/workarea/storefront/google_analytics/modules/adapter.js
@@ -13,7 +13,7 @@ WORKAREA.analytics.registerAdapter('googleAnalytics', function () {
                 console.log(arguments);
             }
 
-            if (!WORKAREA.environment.isTest) {
+            if (!WORKAREA.environment.isTest && !_.isUndefined(window.ga)) {
               ga.apply(ga, arguments);
             }
         };


### PR DESCRIPTION
Instead of seeing whether the app is in the test environment, check
whether the `ga()` function is present before sending any calls to it.
This prevents a JS error that occurs when the
`config.google_analytics_tracking_id` is missing.