### PR TITLE
Ruby 3.2+ Compatibility Updates

### DIFF
--- a/workarea-google_analytics.gemspec
+++ b/workarea-google_analytics.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.license = 'Business Software License'
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.7', '< 3.5'
 
   s.add_dependency 'workarea', '~> 3.x', '>= 3.5.x'
 end


### PR DESCRIPTION
Updates for Ruby 3.2+ compatibility.

- Updated required_ruby_version to `>= 2.7, < 3.5`
- Replaced deprecated Rails APIs (`update_attributes` -> `update`, `to_s(:format)` -> `to_fs(:format)`)
- Replaced deprecated Ruby APIs (`File.exists?` -> `File.exist?`, `Dir.exists?` -> `Dir.exist?`)

Client impact: None — backward compatible